### PR TITLE
Update to `bootstrap` script

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.0",
     "private": true,
     "scripts": {
-      "bootstrap": "flex-check-start",
+      "bootstrap": "flex-plugin check-start",
       "postinstall": "npm run bootstrap",
       "prestart": "npm run bootstrap",
       "start": "craco start",

--- a/template/package.json
+++ b/template/package.json
@@ -19,6 +19,7 @@
       "core-js": "^2.6.5",
       "craco-config-flex-plugin": "{{cracoConfigVersion}}",
       "flex-plugin": "{{flexPluginVersion}}",
+      "flex-plugin-scripts": "^3.3.7",
       "lodash": "^4",
       "react": "^16.8.6",
       "react-dom": "^16.8.6",


### PR DESCRIPTION
The `flex-check-start` has been moved to `flex-plugin` package. Currently this is triggering the following error: 

```bash
$ npm install
...
> sample-plugin@0.0.0 bootstrap /Users/twilio/dev/sample/flex/plugin/plugin-simple-error
> flex-check-start

This script has been moved into `flex-plugin-scripts`. Please update your package.json `scripts`, and replace the `bootstrap` script from

  "bootstrap": "flex-check-start"
```

Update `bootstrap` script accordingly.