### PR TITLE
Align dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,13 @@
       "rimraf": "^3.0.0"
     },
     "dependencies": {
-      "core-js": "^2.6.5",
       "craco-config-flex-plugin": "{{cracoConfigVersion}}",
       "flex-plugin": "{{flexPluginVersion}}",
-      "flex-plugin-scripts": "^3.3.7",
-      "lodash": "^4",
+      "flex-plugin-scripts": "{{pluginScriptsVersion}}",
       "react": "16.5.2",
       "react-dom": "16.5.2",
-      "react-scripts": "3.3.0"
+      "react-emotion": "9.2.6",
+      "react-scripts": "3.4.1"
     },
     "browserslist": {
       "production": [


### PR DESCRIPTION
Update version of `react-scripts` dependency to avoid issues with `webpack`. 

With the opportunity, align package.json to https://github.com/twilio/flex-plugin-builder/blob/19d9a0c065f44d5c8930038be11c49d00ae3d6a8/packages/create-flex-plugin/templates/js/package.json:

* Add `{{pluginScriptsVersion}}` for `flex-plugin-scripts` dependency 
* Add `react-emotion`
* Remove `loadash`
* Remove `core-js`

Closes #3 
